### PR TITLE
return errors instead of panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ func main() {
 		emit.Quit()
 	})
 	
-
 	emit.OnAny(func(message interface{}) {
 		//This get any events
+		fmt.Println("any events!")
 	})
+	
 	emit.Start()
 }
 
@@ -40,5 +41,6 @@ func main() {
 
 Emit of the event
 ```go
-emit.On("disconnect", "now")
+emit.Emit("connect", "abc")
+emit.Emit("disconnect", "now")
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/saromanov/goemits
+module github.com/hzakher/goemits
 
 go 1.14
 


### PR DESCRIPTION
return error `On` event,  `RemoveListener` instead of panic. added a couple of comments